### PR TITLE
Use resin/rpi-raspbian as the base image for the named container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-arch-pi/

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-rm -rf docker-arch-pi
-git clone https://github.com/sktb/docker-arch-pi.git
-cd docker-arch-pi
-./build.sh
-cd ../named
-docker build -t sktb/named .
-cd ../dhcpd
-docker build -t sktb/dhcpd .

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+rm -rf docker-arch-pi
+git clone https://github.com/sktb/docker-arch-pi.git
+cd docker-arch-pi
+./build.sh
+cd ../named
+docker build -t sktb/named .
+cd ../dhcpd
+docker build -t sktb/dhcpd .

--- a/named/Dockerfile
+++ b/named/Dockerfile
@@ -1,11 +1,11 @@
-FROM sktb/arch-pi
+FROM resin/rpi-raspbian
 MAINTAINER Simon K T Burrows <sktburrows@gmail.com>
 
-RUN pacman -S -yy
-RUN pacman -S -q --noconfirm bind
+RUN sudo apt-get -q update
+RUN sudo apt-get -q install bind9
 
 ADD ./named.conf /etc/named.conf
 
 EXPOSE 53/udp
 
-CMD ["/bin/named","-g"]
+CMD ["/usr/sbin/named", "-g"]


### PR DESCRIPTION
The resin/rpi-rasbpian base image is much smaller than the Arch-Linux base image previously used.
